### PR TITLE
replacing the package with current governance contracty version

### DIFF
--- a/contracts/APM.sol
+++ b/contracts/APM.sol
@@ -16,7 +16,7 @@ pragma solidity ^0.8.0;
 import "./interfaces/IAPM.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "debond-governance-contracts/utils/GovernanceOwnable.sol";
+import "debond-governance-contracts/contracts/utils/GovernanceOwnable.sol";
 
 
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@openzeppelin/contracts": "^4.5.0",
-    "debond-governance-contracts": "^0.0.1",
+    "debond-governance-contracts": "https://github.com/Debond-Protocol/Debond-Governance.git",
     "dotenv": "^16.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- the package inherited by the npm package is obsolete, so for now I changed to the current version.